### PR TITLE
Compile resize with pencilcc v0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+pencil-benchmarks-imageproc/build/

--- a/pencil-benchmarks-imageproc/resize/resize.pencil.c
+++ b/pencil-benchmarks-imageproc/resize/resize.pencil.c
@@ -1,6 +1,7 @@
 #include "resize.pencil.h"
 #include <pencil.h>
 
+
 static void resize( const int original_rows
                   , const int original_cols
                   , const int original_step
@@ -32,23 +33,23 @@ static void resize( const int original_rows
             #pragma pencil independent
             for ( int n_c = 0; n_c < resampled_cols; n_c++ )
             {
-                float o_r = ( n_r + 0.5 ) * (o_h) / (n_h) - 0.5;
-                float o_c = ( n_c + 0.5 ) * (o_w) / (n_w) - 0.5;
+                float o_r = ( n_r + 0.5f ) * (o_h) / (n_h) - 0.5f;
+                float o_c = ( n_c + 0.5f ) * (o_w) / (n_w) - 0.5f;
 
-                float r = o_r - floorf(o_r);
-                float c = o_c - floorf(o_c);
+                float r = o_r - floor(o_r);
+                float c = o_c - floor(o_c);
 
-                int coord_00_r = iclampi( (int) floorf(o_r), 0, o_h - 1 );
-                int coord_00_c = iclampi( (int) floorf(o_c), 0, o_w - 1 );
+                int coord_00_r = clamp( (int) floor(o_r), 0, o_h - 1 );
+                int coord_00_c = clamp( (int) floor(o_c), 0, o_w - 1 );
 
                 int coord_01_r = coord_00_r;
-                int coord_01_c = iclampi( coord_00_c + 1, 0, o_w - 1 );
+                int coord_01_c = clamp( coord_00_c + 1, 0, o_w - 1 );
 
-                int coord_10_r = iclampi( coord_00_r + 1, 0, o_h - 1 );
+                int coord_10_r = clamp( coord_00_r + 1, 0, o_h - 1 );
                 int coord_10_c = coord_00_c;
 
-                int coord_11_r = iclampi( coord_00_r + 1, 0, o_h - 1 );
-                int coord_11_c = iclampi( coord_00_c + 1, 0, o_w - 1 );
+                int coord_11_r = clamp( coord_00_r + 1, 0, o_h - 1 );
+                int coord_11_c = clamp( coord_00_c + 1, 0, o_w - 1 );
 
                 unsigned char A00 = original[coord_00_r][coord_00_c];
                 unsigned char A10 = original[coord_10_r][coord_10_c];

--- a/pencil-benchmarks-imageproc/resize/resize.pencil.h
+++ b/pencil-benchmarks-imageproc/resize/resize.pencil.h
@@ -2,10 +2,14 @@
 #define RESIZE_PENCIL_H
 
 #include <stdint.h>
+#include <math.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+// Not defined in math.h.
+int clamp(int, int, int);
 
 void pencil_resize_LN( const int original_rows,  const int original_cols,  const int original_step,  const uint8_t original[]
                      , const int resampled_rows, const int resampled_cols, const int resampled_step,       uint8_t resampled[]

--- a/pencil-benchmarks-imageproc/resize/test_resize.cpp
+++ b/pencil-benchmarks-imageproc/resize/test_resize.cpp
@@ -57,12 +57,12 @@ void time_resize( const std::vector<carp::record_t>& pool, const std::vector<cv:
                         first_execution_pencil = false;
                     }
 
-                    prl_timings_reset();
-                    prl_timings_start();
+                    prl_prof_reset();
+                    prl_prof_start();
                     pencil_resize_LN(cpu_gray.rows, cpu_gray.cols, cpu_gray.step1(), cpu_gray.ptr(), pen_result.rows, pen_result.cols, pen_result.step1(), pen_result.ptr() );
-                    prl_timings_stop();
+                    prl_prof_stop();
                     // Dump execution times for PENCIL code.
-                    prl_timings_dump();
+                    prl_prof_dump();
                 }
                 // Verifying the results - TODO - Something fishy is happening at borders
 #define REMOVE_BORDER(img) img(cv::Range(1, size.height-1), cv::Range(1, size.width-1))
@@ -87,7 +87,7 @@ void time_resize( const std::vector<carp::record_t>& pool, const std::vector<cv:
 
 int main(int argc, char* argv[])
 {
-    prl_init((prl_init_flags)(PRL_TARGET_DEVICE_DYNAMIC | PRL_PROFILING_ENABLED));
+    prl_init();
 
     std::cout << "This executable is iterating over all the files passed to it as an argument. " << std::endl;
 
@@ -103,6 +103,7 @@ int main(int argc, char* argv[])
 
     time_resize( pool, sizes, iteration );
 
-    prl_shutdown();
+    prl_release();
+
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Update the `resize` benchmark in order to be able to compile it with `pencilcc` v0.4.
